### PR TITLE
Support for compile time dependency injection

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,14 +67,29 @@ resolvers ++= Seq(
 ```
 
 
-### 2. Add a line in the configuration file
+### 2. Add the plugin to your application
 
-#### Play 2.4
+#### Play 2.4 runtime dependency injection
 
 Add a line in `conf/application.conf`
 
 ```
 play.modules.enabled += "jp.co.bizreach.play2handlebars.HandlebarsModule"
+```
+
+#### Play 2.4 compile time dependency injection
+
+Extend your application's components with `jp.co.bizreach.play2handlebars.HandlebarsComponents` in your `ApplicationLoader`.
+
+``` scala
+import jp.co.bizreach.play2handlebars.HandlebarsComponents
+
+class MyApplicationLoader extends ApplicationLoader {
+  override def load(context: Context) = new MyAppComponents(context).application
+}
+
+class MyAppComponents(context: Context) extends BuiltInComponentsFromContext(context) with HandlebarsComponents
+
 ```
 
 #### Play 2.3

--- a/src/main/scala/jp/co/bizreach/play2handlebars/HandlebarsPlugin.scala
+++ b/src/main/scala/jp/co/bizreach/play2handlebars/HandlebarsPlugin.scala
@@ -16,7 +16,16 @@ import scala.concurrent.Future
 import scala.concurrent.ExecutionContext.Implicits.global
 
 /**
- * Handlebars Module for Play 2.4 application
+ * Handlebars components for compile time dependency injection in Play 2.4 application
+ */
+trait HandlebarsComponents {
+  def configuration: Configuration
+  def environment: Environment
+  val handlebarsPlugin = new HandlebarsPlugin(configuration, environment)
+}
+
+/**
+ * Handlebars Module for runtime dependency injection in Play 2.4 application
  */
 class HandlebarsModule extends Module {
   def bindings(environment: Environment, configuration: Configuration): Seq[Binding[HandlebarsPlugin]] =


### PR DESCRIPTION
Play 2.4 supports both dependency injection at runtime and at compile time. This Pull requests adds compile time dependency injection without breaking the existing runtime dependency injection.

More about compile time dependency injection can be found in the [associated section of Play documentation](https://www.playframework.com/documentation/2.4.x/ScalaCompileTimeDependencyInjection)
